### PR TITLE
Add setting to set wear limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ woodcutting.settings = {
 	leaves_distance = 2,  -- do not touch leaves around the not removed trees with this distance
 	player_distance = 80, -- Allow cutting tree nodes with this maximum distance away from player
 	dig_leaves = true,    -- Dig dacayable leaves after tree node is digged - can be changed trough woodcutting_dig_leaves in minetest.conf
+	wear_limit = 65535,   -- Maximum tool wear that allows cutting
 }
 ```
 
@@ -49,6 +50,7 @@ See (default) Settings
   - process.leaves_distance - used in process:process_leaves(pos) - can be adjusted each step in on_after_dig_hook()
   - process.player_distance - used in process:check_processing_allowed(pos) - can be adjusted each step in on_step_hook()
   - process.dig_leaves      - used at end of on_dignode function - can be adjusted each step in on_after_dig_hook()
+  - process.wear_limit      - used in process:check_processing_allowed(pos) - can be adjusted each step in on_step_hook()
 
 #### Methods
 Note:this methods could be redefined in on_new_process_hook, in a different way for each new process

--- a/init.lua
+++ b/init.lua
@@ -5,6 +5,7 @@ woodcutting.settings = {
 	leaves_distance = 2,  -- do not touch leaves around the not removed trees with this distance
 	player_distance = 80, -- Allow cutting tree nodes with this maximum distance away from player
 	dig_leaves = true,    -- Dig dacayable leaves after tree node is digged
+	wear_limit = 65535,   -- Maximum tool wear that allows cutting
 
 	on_new_process_hook = function(process) return true end,             -- do not start the process if set to nil or return false
 	on_step_hook = function(process) return true end,                    -- if false is returned finish the process
@@ -36,6 +37,7 @@ function woodcutting.new_process(playername, template)
 	process.tree_distance = process.tree_distance or woodcutting.settings.tree_distance
 	process.leaves_distance = process.leaves_distance or woodcutting.settings.leaves_distance
 	process.player_distance = process.player_distance or woodcutting.settings.player_distance
+	process.wear_limit = process.wear_limit or woodcutting.settings.wear_limit
 
 	if process.dig_leaves == nil then --bool value with default value true
 		if woodcutting.settings.dig_leaves == nil then
@@ -133,6 +135,7 @@ end
 ----------------------------------
 function woodcutting_class:check_processing_allowed(pos)
 	return vector.distance(pos, self._player:get_pos()) < self.player_distance
+		and self._player:get_wielded_item():get_wear() <= self.wear_limit
 end
 
 ----------------------------------


### PR DESCRIPTION
When tool wear is higher than the limit, this stops digging so the tool can be repaired. Nodes are removed from the list one at a time so that it is still possible to switch to a different tool.

This can be disabled by setting the limit to 65535. The default limit is taken from toolranks.