### PR TITLE
amend load print

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -431,3 +431,6 @@ minetest.register_on_leaveplayer(function(player)
 		process:stop_process()
 	end
 end)
+
+-- print to log after mod was loaded successfully
+print ("[MOD] Wood Cutting loaded")


### PR DESCRIPTION
Add a final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

This could be useful not only for player support (e.g. in the MT forum) but would certainly be useful for MT server admins using the CLI and reading their server logs.